### PR TITLE
Footnotes and full text

### DIFF
--- a/content/fulltext.md
+++ b/content/fulltext.md
@@ -1,0 +1,5 @@
+---
+title: Full Text
+type: full
+online: false
+---

--- a/content/journey/farewell-to-kolkata.md
+++ b/content/journey/farewell-to-kolkata.md
@@ -4,6 +4,7 @@ type: notes
 class: splash
 image: /headers/02.jpeg
 weight: 11
+pdf: false
 ---
 
 Protap Chunder Mozoomdar gave a farewell address to his Brahmo Samaj

--- a/content/journey/farewell-to-kolkata.md
+++ b/content/journey/farewell-to-kolkata.md
@@ -1,18 +1,18 @@
 ---
 title: Farewell to Kolkata
-type: page
+type: notes
 class: splash
 image: /headers/02.jpeg
 weight: 11
 ---
 
 Protap Chunder Mozoomdar gave a farewell address to his Brahmo Samaj
-congregation on Sunday evening, July 9, 1893.[^2] Delivered two days
+congregation on Sunday evening, July 9, 1893.{{< q-note "2" >}} Delivered two days
 before his departure for the World's Parliament of Religions in Chicago,
 Mozoomdar's speech is ridden with hopes and fears no doubt heightened by
 what he felt to be a call from God to fulfill the prophecy of global
 religious unity pronounced by his late friend and mentor Keshub Chunder
-Sen.[^3] Before the danger of a long sea journey, PCM worried aloud over
+Sen.{{< q-note "3" >}} Before the danger of a long sea journey, PCM worried aloud over
 his frail health, ability to glorify God, and the loneliness of his wife
 Saudamini, who would stay behind in Kolkata. He sought from his
 listeners both prayers for his wellbeing and the cessation of their
@@ -21,9 +21,3 @@ Brahmo Samaj, PCM called for peace among its factions, the inner strife
 of which threatened any chance for the united theistic brotherhood he
 hoped would result from the World's Parliament of Religions. As will be
 seen, these concerns followed Mozoomdar throughout his westward journey.
-
-[^2]: "Rev. PC. Mozoomdar's Departure for America," *The Interpreter* 2,
-    no.1 (1893): 2.
-
-[^3]: Protap Chunder Mozoomdar, *Lectures in America & Other Papers*
-    (Calcutta: Navavidhan Publication Committee, 1955), 33-41.

--- a/content/journey/intro.md
+++ b/content/journey/intro.md
@@ -4,6 +4,7 @@ type: notes
 class: splash
 image: /headers/01.jpeg
 weight: 10
+pdf: false
 ---
 
 {{< q-figure id="1" label="true" >}}

--- a/content/journey/intro.md
+++ b/content/journey/intro.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-type: page
+type: notes
 class: splash
 image: /headers/01.jpeg
 weight: 10
@@ -18,7 +18,7 @@ seaboard (not to mention the publication of his book, *The Oriental
 Christ*) enamored liberal Christians such as Jenkin Lloyd Jones, a
 Unitarian minister who would help organize the World's Parliament of
 Religions to be held in conjuction with the World's Fair in
-Chicago.[^1] PCM attended and addressed this parliament in order to rally
+Chicago.{{< q-note "1" >}} PCM attended and addressed this parliament in order to rally
 support for the New Dispensation, a Brahmo Samaj vision of global
 religious confraternity that he hoped would mark the end of religious
 sectarianism and restore the prominence of an emotional, rather than
@@ -31,5 +31,3 @@ that prefaced his addresses at the World's Parliament of Religions,
 based on letters he wrote to his wife Saudamini, "Mozoomdar at
 Sea" enables a fuller appreciation of these Chicago lectures, his
 religious mission, and his hope for the New Dispensation.
-
-[^1]: Sunrit Mullick, *The First Hindu Mission to America: The Pioneering Visits of Protap Chunder Mozoomdar* (New Delhi: Northern Book Centre, 2010), 95.

--- a/data/notes.yml
+++ b/data/notes.yml
@@ -1,0 +1,7 @@
+endnotes:
+  - id: "1"
+    note: "Sunrit Mullick, *The First Hindu Mission to America: The Pioneering Visits of Protap Chunder Mozoomdar* (New Delhi: Northern Book Centre, 2010), 95."
+  - id: "2"
+    note: "“Rev. PC. Mozoomdar’s Departure for America,” *The Interpreter* 2, no.1 (1893): 2."
+  - id: "3"
+    note: "Protap Chunder Mozoomdar, *Lectures in America & Other Papers* (Calcutta: Navavidhan Publication Committee, 1955), 33-41."

--- a/layouts/full/single.html
+++ b/layouts/full/single.html
@@ -1,0 +1,34 @@
+{{/*
+
+*/}}
+
+{{ define "main" }}
+
+<div class="{{ partial "page-class.html" . }}" id="main" role="main">
+  {{ partial "page-header.html" . }}
+
+  <section class="section quire-page__content" id="content">
+    <div class="container">
+      <div class="content">
+
+        {{ range where .Site.Pages "Section" "journey" }}
+          <h2>{{ .Title }}</h2>
+          {{ .Content }}
+        {{ end }}
+
+        <div class="footnotes">
+          <hr />
+          <ol>
+            {{ range .Site.Data.notes.endnotes }}
+            <li id="fn:{{ .id }}">{{ markdownify .note }} <a class="footnote-return" href="#fnref:{{ .id }}">↩</a></li>
+            {{ end }}
+          </ol>
+        <div>
+
+
+      </div>
+    </div>
+  </section>
+
+</div>
+{{ end }}

--- a/layouts/notes/single.html
+++ b/layouts/notes/single.html
@@ -1,0 +1,35 @@
+{{/*
+
+A special page type that displays footnotes created by the q-note
+shortcode. Footnotes are formatted the same way they would be if
+created with the default Markdown option, including the back links.
+
+*/}}
+
+{{ define "main" }}
+
+<div class="{{ partial "page-class.html" . }}" id="main" role="main">
+  {{ partial "page-header.html" . }}
+
+  {{ with .Content }}
+  <section class="section quire-page__content" id="content">
+    <div class="container">
+      <div class="content">
+        {{ . }}
+        {{ if ($.Scratch.GetSortedMapValues "footnoted") -}}
+        <div class="footnotes">
+          <hr />
+          <ol start="{{ range first 1 ($.Scratch.GetSortedMapValues "footnoted") }}{{ index . 0 }}{{ end }}">
+            {{ range ($.Scratch.GetSortedMapValues "footnoted") -}}
+            <li id="fn:{{ index . 0 }}">{{ markdownify (index . 1)}} <a class="footnote-return" href="#fnref:{{ index . 0 }}">↩</a></li>
+            {{- end -}}
+          </ol>
+        </div>
+        {{- end }}
+      </div>
+    </div>
+  </section>
+  {{ end }}
+
+</div>
+{{ end }}

--- a/layouts/shortcodes/q-note.html
+++ b/layouts/shortcodes/q-note.html
@@ -1,0 +1,34 @@
+{{/*
+
+  A custom shortcode for alternative footnote handling, based on the standard
+  q-cite shorcode.
+
+*/}}
+
+{{- $id := .Get 0 -}}
+
+{{- range $.Site.Data.notes.endnotes -}}
+    {{- if eq .id $id -}}
+        {{- $.Scratch.Add "note" .note -}}
+    {{- end -}}
+{{- end -}}
+
+{{- if eq ($.Scratch.Get "note") nil -}}
+
+{{- else -}}
+
+  {{- $note := $.Scratch.Get "note" -}}
+  {{- $.Page.Scratch.SetInMap "footnote" "0" $id -}}
+  {{- $.Page.Scratch.SetInMap "footnote" "1" $note -}}
+  {{- $footnote := ($.Page.Scratch.GetSortedMapValues "footnote") -}}
+  {{- $.Page.Scratch.SetInMap "footnoted" $id $footnote -}}
+  <a href="#fn:{{ $id }}" rel="footnote" class="quire-citation"><span class="visually-hidden">Note: </span><sup class="footnote-ref" id="fnref:{{ $id }}">{{ $id }}</sup><span class="quire-citation__content">{{ $note | markdownify }}</span></a>
+
+
+  {{- $.Scratch.SetInMap "endnote" "0" $id -}}
+  {{- $.Scratch.SetInMap "endnote" "1" $note -}}
+  {{- $endnote := ($.Scratch.GetSortedMapValues "endnote") -}}
+  {{- $.Scratch.SetInMap "endnoted" $id $endnote -}}
+
+
+{{- end -}}


### PR DESCRIPTION
This adds some support for alternate footnotes and a full text page for your PDF output. Hopefully the samples and the notes below will be clear enough, but let me know if you have questions. 

**For footnotes:**

- List all footnotes with their `id` numbers and `note` text in the new `data/notes.yml` file as indicated in the sample included. Texts and IDs should be surrounded in straight quotes, but be sure that no other straight quotes are used within the text or the [YAML won't be valid](https://gettypubs.github.io/quire/guide/fundamentals/#yaml-basics).
- Add footnotes to individual pages with the shortcode, referencing the footnote number: `{{< q-note "1" >}}`
- Delete old footnote references, including the notes themselves at the bottom of the Markdown files.
- Change the page `type` to `type: notes` to display the footnotes at the bottom of the page. Otherwise, they'll only be available on hover.

**For the full text page:**

- This is collecting all the texts from within the `journey` section of the publication. This can be adjusted by customizing the `range` on line 14 of the `layouts/full/single.html` file.
- A full set of footnotes is generated from `notes.yml` and included at the bottom of this page
- You'll also need to add `pdf: false` to the YAML of the Markdown files you don't want individually rendered.

